### PR TITLE
Expose input method in DSL

### DIFF
--- a/lib/formulaic/dsl.rb
+++ b/lib/formulaic/dsl.rb
@@ -3,5 +3,9 @@ module Formulaic
     def fill_form(model_name, attributes)
       Form.new(model_name, attributes).fill
     end
+
+    def input(model_name, field, action = :create)
+      Label.new(model_name, field, action).to_str
+    end
   end
 end

--- a/spec/formulaic/dsl_spec.rb
+++ b/spec/formulaic/dsl_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Formulaic::Dsl do
+  it 'responds to input' do
+    expect(object_with_dsl).to respond_to(:input)
+  end
+
+  it 'responds to fill_form' do
+    expect(object_with_dsl).to respond_to(:fill_form)
+  end
+
+  def object_with_dsl
+    @object_with_dsl ||= Class.new do
+      include Formulaic::Dsl
+    end.new
+  end
+end

--- a/spec/formulaic/label_spec.rb
+++ b/spec/formulaic/label_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 describe Formulaic::Label do
   it 'returns the string if there are no translations and it can not human_attribute_name the class' do


### PR DESCRIPTION
Finds translations for inputs based on model name and field, with
optional action defaulting to `:create`.
