### PR TITLE
Assign license to thoughtbot

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013 Caleb Thompson
+Copyright (c) 2013 Caleb Thompson and thoughtbot
 
 MIT License
 


### PR DESCRIPTION
Since this is a thoughtbot open source project in the thoughtbot
organization, the copyright should be held (in part, at least) by
thoughtbot.
