### PR TITLE
Fixed `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The `model_name` and `action` should match up to the
 # spec/spec_helper.rb
 
 RSpec.configure do |config|
-  config.include Formulaic::Dsl
+  config.include Formulaic::Dsl, type: :feature
 end
 ```
 


### PR DESCRIPTION
Only include `Formulaic::Dsl` in integration specs, as discussed
[here](https://github.com/thoughtbot/suspenders/pull/350#discussion_r13015159)
