### PR TITLE
Add fill_form_and_submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ end
 ### `fill_form`
 
 ```ruby
-fill_form(model_name, attributes)
+fill_form(model_name, action = :new, attributes)
 ```
 
 `fill_form` provides an interface to completely filling out a form. Provide the
@@ -68,6 +68,15 @@ submit(:user, :update)
 
 The `model_name` and `action` should match up to the
 `helpers.submit.<model_name>.<action>` translations.
+
+### `fill_form_and_submit`
+
+```ruby
+fill_form_and_submit(:user, action = :new, attributes)
+```
+
+Effectively a `fill_form` followed by `click_on submit`, but smart enough to
+`fill_form` with `:new` and `submit` with `:create` and the edit/update cousin.
 
 ### Nested Forms
 
@@ -153,7 +162,8 @@ around `I18n.t`.
   the labels to determine where to fill what data.
 * Formulaic can’t figure out how to fill fields with HTML labels:
   `page.fill_in('<strong>Text</strong> here', with: 'something')` doesn’t work
-  with Capybara. The usual workaround is to pass a CSS selector.
+  with Capybara. The usual workaround is to pass a CSS selector (which you can
+  do by passing a string as the attribute key).
 * Formulaic can't handle multiple file attachments on the same input.
 
 ## About

--- a/lib/formulaic/dsl.rb
+++ b/lib/formulaic/dsl.rb
@@ -4,6 +4,13 @@ module Formulaic
       Form.new(model_name, action, attributes).fill
     end
 
+    def fill_form_and_submit(model_name, action = :new, attributes)
+      form_action_to_submit_action = { new: :create, edit: :update }
+      fill_form(model_name, action, attributes)
+      submit_action = form_action_to_submit_action[action] || action
+      click_on submit(model_name, submit_action)
+    end
+
     def input(model_name, field, action = :new)
       Label.new(model_name, field, action).to_str
     end

--- a/spec/formulaic/dsl_spec.rb
+++ b/spec/formulaic/dsl_spec.rb
@@ -48,10 +48,26 @@ describe Formulaic::Dsl do
     end
   end
 
-  it 'finds a submit label' do
-    I18n.backend.store_translations(:en, { helpers: { submit: { user: { create: 'Create user' } } } })
+  describe 'submit' do
+    it 'finds a submit label' do
+      I18n.backend.store_translations(:en, { helpers: { submit: { user: { create: 'Create user' } } } })
 
-    expect(object_with_dsl.submit(:user)).to eq 'Create user'
+      expect(object_with_dsl.submit(:user)).to eq 'Create user'
+    end
+  end
+
+  describe 'fill_form_and_submit' do
+    it 'fills a form and submits it' do
+      I18n.backend.store_translations(:en, { helpers: { submit: { model: { create: 'Create model' } } } })
+      allow(Formulaic::Form).to receive(:new).and_return(double(fill: nil))
+      allow(object_with_dsl).to receive(:click_on)
+
+      object_with_dsl.fill_form_and_submit :model, attributes: :values
+
+      expect(Formulaic::Form).to have_received(:new)
+        .with(:model, :new, attributes: :values)
+      expect(object_with_dsl).to have_received(:click_on).with('Create model')
+    end
   end
 
   def object_with_dsl


### PR DESCRIPTION
The pattern of filling a form then immediately submitting seems to be the most common interaction, and the more I use this the more I think they should be combined.

I'd like to keep both helpers separate as well in case there is something that needs to be done between the interactions, so this would be an addition to the public interface.
