### PR TITLE
Make date input field name gsub indepedent of select box order

### DIFF
--- a/lib/formulaic/inputs/date_input.rb
+++ b/lib/formulaic/inputs/date_input.rb
@@ -8,7 +8,7 @@ module Formulaic
       private
 
       def select_date(date, options)
-        field = find_field(options[:from].to_s)["id"].gsub(/_1i/, "")
+        field = find_field(options[:from].to_s)["id"].gsub(/_\di/, "")
         select date.year.to_s, from: "#{field}_1i"
         select Date::MONTHNAMES[date.month], from: "#{field}_2i"
         select date.day.to_s, from: "#{field}_3i"

--- a/spec/features/fill_in_user_form_spec.rb
+++ b/spec/features/fill_in_user_form_spec.rb
@@ -106,4 +106,23 @@ describe 'Fill in user form' do
 
     expect(input(:user, :avatar).value).to eq file.path
   end
+
+  it 'finds and fills a date field regardless of select box order' do
+    visit 'event_form'
+
+    form = Formulaic::Form.new(:event, :new,
+                               "Starts on" => Date.new(2014, 3, 4),
+                               "Ends on" =>  Date.new(2015, 12, 31))
+
+    form.fill
+
+    expect(page.find('#event_starts_on_1i').value).to eq('2014')
+    expect(page.find('#event_starts_on_2i').value).to eq('3')
+    expect(page.find('#event_starts_on_3i').value).to eq('4')
+
+    expect(page.find('#event_ends_on_1i').value).to eq('2015')
+    expect(page.find('#event_ends_on_2i').value).to eq('12')
+    expect(page.find('#event_ends_on_3i').value).to eq('31')
+  end
+
 end

--- a/spec/fixtures/event_form.html
+++ b/spec/fixtures/event_form.html
@@ -1,0 +1,114 @@
+<form accept-charset="UTF-8" action="/events" class="simple_form new_event" id="new_event" method="post" novalidate="novalidate">
+  <div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="✓"><input name="authenticity_token" type="hidden" value="O6ORla31JvEaWroCuiA7bArM15ztDotMfPAbNW0v61g="></div>
+  <div class="input date required event_starts_on">
+    <label class="date required" for="event_starts_on_2i"><abbr title="required">*</abbr> Starts on</label>
+    <select class="date required" id="event_starts_on_2i" name="event[starts_on(2i)]">
+      <option value="1">January</option>
+      <option value="2">February</option>
+      <option value="3">March</option>
+      <option value="4">April</option>
+      <option value="5">May</option>
+      <option selected="selected" value="6">June</option>
+      <option value="7">July</option>
+      <option value="8">August</option>
+      <option value="9">September</option>
+      <option value="10">October</option>
+      <option value="11">November</option>
+      <option value="12">December</option>
+    </select>
+    <select class="date required" id="event_starts_on_3i" name="event[starts_on(3i)]">
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+      <option value="4">4</option>
+      <option value="5">5</option>
+      <option value="6">6</option>
+      <option selected="selected" value="7">7</option>
+      <option value="8">8</option>
+      <option value="9">9</option>
+      <option value="10">10</option>
+      <option value="11">11</option>
+      <option value="12">12</option>
+      <option value="13">13</option>
+      <option value="14">14</option>
+      <option value="15">15</option>
+      <option value="16">16</option>
+      <option value="17">17</option>
+      <option value="18">18</option>
+      <option value="19">19</option>
+      <option value="20">20</option>
+      <option value="21">21</option>
+      <option value="22">22</option>
+      <option value="23">23</option>
+      <option value="24">24</option>
+      <option value="25">25</option>
+      <option value="26">26</option>
+      <option value="27">27</option>
+      <option value="28">28</option>
+      <option value="29">29</option>
+      <option value="30">30</option>
+      <option value="31">31</option>
+    </select>
+    <select class="date required" id="event_starts_on_1i" name="event[starts_on(1i)]">
+      <option value="2016">2016</option>
+      <option value="2015">2015</option>
+      <option value="2014">2014</option>
+    </select>
+  </div>
+  <div class="input date required event_ends_on">
+    <label class="date required" for="event_ends_on_3i">Ends on</label>
+    <select class="date required" id="event_ends_on_3i" name="event[ends_on(3i)]">
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+      <option value="4">4</option>
+      <option value="5">5</option>
+      <option value="6">6</option>
+      <option selected="selected" value="7">7</option>
+      <option value="8">8</option>
+      <option value="9">9</option>
+      <option value="10">10</option>
+      <option value="11">11</option>
+      <option value="12">12</option>
+      <option value="13">13</option>
+      <option value="14">14</option>
+      <option value="15">15</option>
+      <option value="16">16</option>
+      <option value="17">17</option>
+      <option value="18">18</option>
+      <option value="19">19</option>
+      <option value="20">20</option>
+      <option value="21">21</option>
+      <option value="22">22</option>
+      <option value="23">23</option>
+      <option value="24">24</option>
+      <option value="25">25</option>
+      <option value="26">26</option>
+      <option value="27">27</option>
+      <option value="28">28</option>
+      <option value="29">29</option>
+      <option value="30">30</option>
+      <option value="31">31</option>
+    </select>
+    <select class="date required" id="event_ends_on_2i" name="event[ends_on(2i)]">
+      <option value="1">January</option>
+      <option value="2">February</option>
+      <option value="3">March</option>
+      <option value="4">April</option>
+      <option value="5">May</option>
+      <option selected="selected" value="6">June</option>
+      <option value="7">July</option>
+      <option value="8">August</option>
+      <option value="9">September</option>
+      <option value="10">October</option>
+      <option value="11">November</option>
+      <option value="12">December</option>
+    </select>
+    <select class="date required" id="event_ends_on_1i" name="event[ends_on(1i)]">
+      <option value="2016">2016</option>
+      <option value="2015">2015</option>
+      <option value="2014">2014</option>
+    </select>
+  </div>
+  <input name="commit" type="submit" value="Save">
+</form>


### PR DESCRIPTION
Date field label target may be tied to any of the day, month, year
select box inputs; for example, simple_form chooses the first:
https://github.com/plataformatec/simple_form/blob/6f2a61015098d43baac67a5f64c5fb4ba9031426/lib/simple_form/inputs/date_time_input.rb#L20

This minor change ensures the matcher will parse the correct field
name regardless of the order.
