### PR TITLE
add configurable default_wait_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ it knows to pass directly to `fill_in` rather than trying to find a translation.
 You’ll need to find submit buttons yourself since `submit` is a thin wrapper
 around `I18n.t`.
 
+Formulaic assumes your forms don't use AJAX, setting the wait time to 0. This can be configured using:
+```ruby
+Formulaic.default_wait_time = 5
+```
+
 ## Known Limitations
 
 * Formulaic currently supports the following mappings from the `#class` of the

--- a/lib/formulaic.rb
+++ b/lib/formulaic.rb
@@ -7,4 +7,15 @@ require 'formulaic/form'
 require 'formulaic/dsl'
 
 module Formulaic
+  class << self
+    attr_accessor :default_wait_time
+
+    def configure
+      yield self
+    end
+  end
+end
+
+Formulaic.configure do |config|
+  config.default_wait_time = 0
 end

--- a/lib/formulaic/inputs/string_input.rb
+++ b/lib/formulaic/inputs/string_input.rb
@@ -2,9 +2,9 @@ module Formulaic
   module Inputs
     class StringInput < Input
       def fill
-        if page.has_selector?(:fillable_field, label)
+        if page.has_selector?(:fillable_field, label, wait: Formulaic.default_wait_time)
           fill_in(label, with: value)
-        elsif page.has_selector?(:radio_button, label)
+        elsif page.has_selector?(:radio_button, label, wait: Formulaic.default_wait_time)
           choose(value)
         elsif has_option_in_select?(value, label)
           select(value, from: label)
@@ -14,7 +14,7 @@ module Formulaic
       end
 
       def has_option_in_select?(option, select)
-        find(:select, select).has_selector?(:option, option)
+        find(:select, select).has_selector?(:option, option, wait: Formulaic.default_wait_time)
       rescue Capybara::ElementNotFound
         false
       end


### PR DESCRIPTION
Adds the config option `default_wait_time` which defaults to 0. Making js tests fast :+1: 
If you have some AJAX form you can configure it `Formulaic.default_wait_time = 5`