### PR TITLE
Allow assocation checkboxes to be filled

### DIFF
--- a/lib/formulaic/inputs/checkbox_input.rb
+++ b/lib/formulaic/inputs/checkbox_input.rb
@@ -28,8 +28,17 @@ module Formulaic
         "input[type='checkbox'][name='#{label.model_name}[#{label.attribute}][]']"
       end
 
+      def checkbox_name_selector_for_association
+        "input[type='checkbox'][name='#{label.model_name}[#{label.attribute.to_s.singularize}_ids][]']"
+      end
+
       def checkbox_labels_selector
-        "#{checkbox_name_selector} ~ label,label:has(#{checkbox_name_selector})"
+        [
+          "#{checkbox_name_selector} ~ label",
+          "label:has(#{checkbox_name_selector})",
+          "#{checkbox_name_selector_for_association} ~ label",
+          "label:has(#{checkbox_name_selector_for_association})",
+        ].join(",")
       end
     end
   end

--- a/spec/features/fill_in_user_form_spec.rb
+++ b/spec/features/fill_in_user_form_spec.rb
@@ -206,4 +206,13 @@ describe 'Fill in user form' do
     expect(page.find('#event_ends_on_3i').value).to eq('31')
   end
 
+  it 'knows to use _ids for association fields' do
+    visit 'user_form'
+
+    form = Formulaic::Form.new(:user, :new, friends: ['Caleb'])
+
+    form.fill
+
+    expect(page.find('#user_friend_ids_1')).to be_checked
+  end
 end

--- a/spec/fixtures/user_form.html
+++ b/spec/fixtures/user_form.html
@@ -43,6 +43,17 @@
     </span>
     <input name="user[dislikes][]" type="hidden" value="">
   </div>
+  <div class="input check_boxes optional user_friends">
+    <label class="check_boxes optional">Friends</label>
+    <span class="checkbox">
+      <label for="user_friend_ids_1">
+        <input class="check_boxes optional" type="checkbox" value="1" name="user[friend_ids][]" id="user_friend_ids_1">
+        Caleb
+      </label>
+    </span>
+    <input type="hidden" name="user[friend_ids][]" value="">
+  </div>
+
   <div class="input text required user_bio"><label class="text required"
       for="user_bio"><abbr title="required">*</abbr> Your Biography</label><textarea class="text required" cols="40" id="user_bio" name="user[bio]" rows="20" style="overflow: hidden; word-wrap: break-word; resize: horizontal; height: 464px;"></textarea></div>
   <div class="input date required user_date_of_birth">


### PR DESCRIPTION
For an input such as `f.association :friends, as: :check_boxes`, we can now
`fill_form(:user, friends: ['Caleb', 'Rufino'])` and check the appropriate
boxes.