### PR TITLE
submit translations fall back to defaults

### DIFF
--- a/lib/formulaic/dsl.rb
+++ b/lib/formulaic/dsl.rb
@@ -16,7 +16,8 @@ module Formulaic
     end
 
     def submit(model_class, action = :create)
-      I18n.t([:helpers, :submit, model_class, action].join('.'))
+      I18n.t("#{model_class}.#{action}", scope: [:helpers, :submit],
+        default: action, model: model_class.to_s.humanize)
     end
   end
 end

--- a/lib/formulaic/dsl.rb
+++ b/lib/formulaic/dsl.rb
@@ -16,8 +16,10 @@ module Formulaic
     end
 
     def submit(model_class, action = :create)
-      I18n.t("#{model_class}.#{action}", scope: [:helpers, :submit],
-        default: action, model: model_class.to_s.humanize)
+      I18n.t "#{model_class}.#{action}",
+             scope: [:helpers, :submit],
+             model: model_class.to_s.humanize,
+             default: action
     end
   end
 end

--- a/spec/formulaic/dsl_spec.rb
+++ b/spec/formulaic/dsl_spec.rb
@@ -53,6 +53,8 @@ describe Formulaic::Dsl do
       I18n.backend.store_translations(:en, { helpers: { submit: { user: { create: 'Create user' } } } })
 
       expect(object_with_dsl.submit(:user)).to eq 'Create user'
+
+      I18n.backend.store_translations(:en, { helpers: { submit: { user: { create: nil } } } })
     end
 
     it 'finds the default submit label' do
@@ -71,6 +73,8 @@ describe Formulaic::Dsl do
       expect(Formulaic::Form).to have_received(:new)
         .with(:model, :new, attributes: :values)
       expect(object_with_dsl).to have_received(:click_on).with('Create model')
+
+      I18n.backend.store_translations(:en, { helpers: { submit: { model: { create: nil } } } })
     end
   end
 

--- a/spec/formulaic/dsl_spec.rb
+++ b/spec/formulaic/dsl_spec.rb
@@ -49,10 +49,14 @@ describe Formulaic::Dsl do
   end
 
   describe 'submit' do
-    it 'finds a submit label' do
+    it 'finds a custom submit label' do
       I18n.backend.store_translations(:en, { helpers: { submit: { user: { create: 'Create user' } } } })
 
       expect(object_with_dsl.submit(:user)).to eq 'Create user'
+    end
+
+    it 'finds the default submit label' do
+      expect(object_with_dsl.submit(:user)).to eq 'Create User'
     end
   end
 

--- a/spec/formulaic/label_spec.rb
+++ b/spec/formulaic/label_spec.rb
@@ -13,6 +13,8 @@ describe Formulaic::Label do
     I18n.backend.store_translations(:en, { simple_form: { labels: { user: { name: "Translated" } } } } )
 
     expect(label(:user, :name)).to eq("Translated")
+
+    I18n.backend.store_translations(:en, { simple_form: { labels: { user: { name: nil } } } } )
   end
 
   it "should leave cases alone" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,11 @@ module SpecHelper
 
   def load_translations
     I18n.backend.store_translations(:en, YAML.load(<<-TRANSLATIONS))
+        helpers:
+          submit:
+            create: 'Create %{model}'
+            update: 'Update %{model}'
+            submit: 'Save %{model}'
         simple_form:
           labels:
             user:


### PR DESCRIPTION
Allow lookup for submit translation to follow same defaults as the form builder submit helper. This allows formulaic to be more flexible in finding the proper translation (similar to what is done for labels).