### PR TITLE
Adds splat operator to FactoryGirl example

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ You may have attributes included in your `User` factory that don’t pertain to
 sign up:
 
 ```ruby
-fill_form(:user, attributes_for(:user).slice(sign_up_attributes))
+fill_form(:user, attributes_for(:user).slice(*sign_up_attributes))
 
 # ...
 def sign_up_attributes


### PR DESCRIPTION
Adds missing splat operator to the second "Integration with FactoryGirl" example.

> If you have an array of keys you want to limit to, you should splat them

http://api.rubyonrails.org/classes/Hash.html#method-i-slice