### PR TITLE
Treat `Symbol` values as string input

### DIFF
--- a/lib/formulaic/form.rb
+++ b/lib/formulaic/form.rb
@@ -8,6 +8,7 @@ module Formulaic
       DateTime => Formulaic::Inputs::DateTimeInput,
       Array => Formulaic::Inputs::ArrayInput,
       String => Formulaic::Inputs::StringInput,
+      Symbol => Formulaic::Inputs::StringInput,
       Fixnum => Formulaic::Inputs::StringInput,
       Float => Formulaic::Inputs::StringInput,
       TrueClass => Formulaic::Inputs::BooleanInput,

--- a/spec/features/fill_in_user_form_spec.rb
+++ b/spec/features/fill_in_user_form_spec.rb
@@ -14,6 +14,14 @@ describe 'Fill in user form' do
     expect(input(:user, :name).value).to eq 'George'
   end
 
+  it 'finds and fills text fields with symbol values' do
+    visit 'user_form'
+    form = Formulaic::Form.new(:user, :new, name: :George)
+    form.fill
+
+    expect(input(:user, :name).value).to eq 'George'
+  end
+
   it 'finds and fills a password field' do
     visit 'user_form'
     form = Formulaic::Form.new(:user, :new, password: 'supersecr3t')


### PR DESCRIPTION
This pull request ensures that `Symbol` values are treated as strings and therefore handled by the `StringInput` class as well.