### PR TITLE
Try translating option for select in StringInput

### DIFF
--- a/lib/formulaic/errors.rb
+++ b/lib/formulaic/errors.rb
@@ -1,3 +1,4 @@
 module Formulaic
   class InputNotFound < StandardError; end
+  class OptionForSelectInputNotFound < StandardError; end
 end

--- a/lib/formulaic/form.rb
+++ b/lib/formulaic/form.rb
@@ -8,6 +8,7 @@ module Formulaic
       DateTime => Formulaic::Inputs::DateTimeInput,
       Array => Formulaic::Inputs::ArrayInput,
       String => Formulaic::Inputs::StringInput,
+      Symbol => Formulaic::Inputs::StringInput,
       Fixnum => Formulaic::Inputs::StringInput,
       Float => Formulaic::Inputs::StringInput,
       TrueClass => Formulaic::Inputs::BooleanInput,

--- a/lib/formulaic/inputs/input.rb
+++ b/lib/formulaic/inputs/input.rb
@@ -7,7 +7,7 @@ module Formulaic
       include Capybara::DSL
 
       def initialize(label, value)
-        @label = label.to_str
+        @label = label
         @value = value
       end
 

--- a/lib/formulaic/inputs/string_input.rb
+++ b/lib/formulaic/inputs/string_input.rb
@@ -6,17 +6,36 @@ module Formulaic
           fill_in(label, with: value)
         elsif page.has_selector?(:radio_button, label, wait: Formulaic.default_wait_time)
           choose(value)
-        elsif has_option_in_select?(value, label)
-          select(value, from: label)
+        elsif has_option_in_select?(translate_option(value), label)
+          select(translate_option(value), from: label)
         else
           raise Formulaic::InputNotFound.new(%[Unable to find input "#{label}".])
         end
       end
 
       def has_option_in_select?(option, select)
-        find(:select, select).has_selector?(:option, option, wait: Formulaic.default_wait_time)
+        element = find(:select, select)
+        unless element.has_selector? :option, option, wait: Formulaic.default_wait_time
+          raise Formulaic::OptionForSelectInputNotFound.new(%[Unable to find option with text matching "#{option}".])
+        end
+        true
       rescue Capybara::ElementNotFound
         false
+      end
+
+      private
+
+      def translate_option(option)
+        I18n.t(lookup_paths_for_option.first,
+               scope: :'simple_form.options', default: lookup_paths_for_option)
+      end
+
+      def lookup_paths_for_option
+        [
+          :"#{label.model_name}.#{label.attribute}.#{value}",
+          :"defaults.#{label.attribute}.#{value}",
+          value.to_s,
+        ]
       end
     end
   end

--- a/lib/formulaic/inputs/string_input.rb
+++ b/lib/formulaic/inputs/string_input.rb
@@ -15,7 +15,7 @@ module Formulaic
 
       def has_option_in_select?(option, select)
         element = find(:select, select)
-        unless element.has_selector? :option, option, wait: Formulaic.default_wait_time
+        if ! element.has_selector?(:option, option, wait: Formulaic.default_wait_time)
           raise Formulaic::OptionForSelectInputNotFound.new(%[Unable to find option with text matching "#{option}".])
         end
         true

--- a/spec/features/fill_in_user_form_spec.rb
+++ b/spec/features/fill_in_user_form_spec.rb
@@ -224,4 +224,24 @@ describe 'Fill in user form' do
 
     expect(page.find('#user_friend_ids_1')).to be_checked
   end
+
+  it 'raises an useful error when option not found for select' do
+    visit 'user_form'
+
+    form = Formulaic::Form.new(:user, :new, role: :unknown)
+
+    expect { form.fill }
+      .to raise_error(
+        Formulaic::OptionForSelectInputNotFound,
+        %[Unable to find option with text matching "unknown".])
+  end
+
+  it 'translate option for select when translation is available' do
+    visit 'user_form'
+
+    form = Formulaic::Form.new(:user, :new, role: :admin)
+    form.fill
+
+    expect(page).to have_select('user_role', selected: 'Administrator')
+  end
 end

--- a/spec/fixtures/user_form.html
+++ b/spec/fixtures/user_form.html
@@ -302,5 +302,13 @@
     </select>
   </div>
   <div class="input boolean required user_terms_of_service"><input name="user[terms_of_service]" type="hidden" value="0"><input class="boolean required" id="user_terms_of_service" name="user[terms_of_service]" type="checkbox" value="1"><label class="boolean required" for="user_terms_of_service"><abbr title="required">*</abbr> I agree to the Terms of Service</label></div>
+  <div class="input select required user_role">
+    <label class="select required" for="user_role"><abbr title="required">*</abbr> Role</label>
+    <select class="select required" name="user[role]" id="user_role">
+      <option value=""></option>
+      <option selected="selected" value="member">Member</option>
+      <option value="admin">Administrator</option>
+    </select>
+  </div>
   <input name="commit" type="submit" value="Register">
 </form>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,11 @@ module SpecHelper
                 phone: Phone Number
                 terms_of_service: I agree to the Terms of Service
                 url: Website
+          options:
+            user:
+              role:
+                admin: Administrator
+                member: Member
     TRANSLATIONS
     I18n.backend.store_translations(:es, YAML.load(<<-TRANSLATIONS))
       date:


### PR DESCRIPTION
This will try translating the given option as defined by simple_form and
fallback to the actual value if no translation is found. If no option is
found matching the given value a more useful error will be raised
telling the user an option matching the given input was not found.

For now, I've only implemented this for `StringInput`. I'm aware we have other input classes working with select elements that also would benefit from this change. I'd love to discuss how we implement this nicely so all relevant input classes can benefit from this change.

/cc @calebthompson 