### PR TITLE
Ensure pristine state for translations

### DIFF
--- a/spec/features/fill_in_user_form_spec.rb
+++ b/spec/features/fill_in_user_form_spec.rb
@@ -2,9 +2,6 @@ require 'spec_helper'
 require 'pathname'
 
 describe 'Fill in user form' do
-
-  before(:all) { load_translations }
-
   it 'finds and fills text fields' do
     visit 'user_form'
     form = Formulaic::Form.new(:user, :new, name: 'George')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,8 @@ module SpecHelper
               end
   end
 
-  def load_translations
+  def reset_and_load_translations
+    I18n.reload!
     I18n.backend.store_translations(:en, YAML.load(<<-TRANSLATIONS))
         helpers:
           submit:
@@ -61,6 +62,10 @@ module SpecHelper
   end
 end
 
-RSpec.configure do |c|
-  c.include SpecHelper
+RSpec.configure do |config|
+  config.include SpecHelper
+
+  config.before(:each) do
+    reset_and_load_translations
+  end
 end


### PR DESCRIPTION
Depending on the order tests ran the `I18n` backend could end up with
messed up translations. This commit addresses the issue by ensuring a
pristine state before each test run.

You can now happily run RSpec with a random seed:

    rspec --order random