### PR TITLE
Allow single test file to run without failing

### DIFF
--- a/spec/formulaic/label_spec.rb
+++ b/spec/formulaic/label_spec.rb
@@ -25,12 +25,6 @@ describe Formulaic::Label do
     expect(label(:student, "Course selection")).to eq "Course selection"
   end
 
-  class User
-    def self.human_attribute_name(attribute)
-      attribute.to_s.humanize
-    end
-  end
-
   def label(model_name, attribute, action = :new)
     Formulaic::Label.new(model_name, attribute, action).to_str
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'formulaic'
 
+Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |f| require f }
+
 module SpecHelper
   def input(model, field)
     page.find("##{model}_#{field}")

--- a/spec/support/models/user.rb
+++ b/spec/support/models/user.rb
@@ -1,0 +1,5 @@
+class User
+  def self.human_attribute_name(attribute)
+    attribute.to_s.humanize
+  end
+end


### PR DESCRIPTION
Before, running single test files dependent on the `User` test class
would fail if `spec/formulaic/label_spec.rb` was not run first.

This commit addresses the issue by requiring test classes in the
`spec/spec_helper.rb` instead. Now all test files can be run
independently.