### PR TITLE
Add param to translation lookup

### DIFF
--- a/lib/formulaic/form.rb
+++ b/lib/formulaic/form.rb
@@ -18,6 +18,7 @@ module Formulaic
 
     def initialize(model_name, action, attributes)
       @action = action
+      @role = extract_presenter(attributes)
       @inputs = build_inputs(model_name, attributes)
     end
 
@@ -27,7 +28,7 @@ module Formulaic
 
     private
 
-    attr_reader :model_name, :inputs, :action
+    attr_reader :model_name, :inputs, :action, :role
 
     def build_inputs(model_name, attributes)
       attributes.map do |field, value|
@@ -36,7 +37,7 @@ module Formulaic
     end
 
     def build_input(model_name, field, value)
-      label = Label.new(model_name, field, action)
+      label = Label.new(model_name, field, action, role)
       input_class_for(value).new(label, value)
     end
 
@@ -44,6 +45,10 @@ module Formulaic
       ATTRIBUTE_INPUT_MAP.fetch(value.class) do
         raise InvalidAttributeTypeError.new("Formulaic does not know how to fill in a #{value.class} value")
       end
+    end
+
+    def extract_presenter(attributes)
+      attributes.delete(:user_role)
     end
 
     class InvalidAttributeTypeError < StandardError; end

--- a/lib/formulaic/label.rb
+++ b/lib/formulaic/label.rb
@@ -1,11 +1,12 @@
 module Formulaic
   class Label
-    attr_reader :model_name, :attribute, :action
+    attr_reader :model_name, :attribute, :action, :role
 
-    def initialize(model_name, attribute, action)
+    def initialize(model_name, attribute, action, role)
       @model_name = model_name
       @attribute = attribute
       @action = action
+      @role = role
     end
 
     def to_str
@@ -34,6 +35,7 @@ module Formulaic
 
     def lookup_paths
       [
+        :"#{model_name}.#{attribute}.#{role}",
         :"#{model_name}.#{action}.#{attribute}",
         :"#{model_name}.#{attribute}",
         :"defaults.#{action}.#{attribute}",

--- a/spec/formulaic/label_spec.rb
+++ b/spec/formulaic/label_spec.rb
@@ -25,7 +25,7 @@ describe Formulaic::Label do
     expect(label(:student, "Course selection")).to eq "Course selection"
   end
 
-  def label(model_name, attribute, action = :new)
-    Formulaic::Label.new(model_name, attribute, action).to_str
+  def label(model_name, attribute, action = :new, role = :as_patient)
+    Formulaic::Label.new(model_name, attribute, action, role).to_str
   end
 end


### PR DESCRIPTION
In order to complete [this task](https://github.com/EpionHealth/patient-check-in/pull/1203) we would like to update formulaic to accept the additional parameter of the user's role. Since i18n translations can be dynamic based on `user_role` (i.e. Patient or Caregiver), the `fill_form`s on our tests must be dynamic as well.