### PR TITLE
translation lookup permits presenters

### DIFF
--- a/lib/formulaic/form.rb
+++ b/lib/formulaic/form.rb
@@ -18,6 +18,7 @@ module Formulaic
 
     def initialize(model_name, action, attributes)
       @action = action
+      @presenter = attributes.delete(:presenter)
       @inputs = build_inputs(model_name, attributes)
     end
 
@@ -27,7 +28,7 @@ module Formulaic
 
     private
 
-    attr_reader :model_name, :inputs, :action
+    attr_reader :model_name, :inputs, :action, :presenter
 
     def build_inputs(model_name, attributes)
       attributes.map do |field, value|
@@ -36,7 +37,7 @@ module Formulaic
     end
 
     def build_input(model_name, field, value)
-      label = Label.new(model_name, field, action)
+      label = Label.new(model_name, field, action, presenter)
       input_class_for(value).new(label, value)
     end
 

--- a/lib/formulaic/label.rb
+++ b/lib/formulaic/label.rb
@@ -1,11 +1,12 @@
 module Formulaic
   class Label
-    attr_reader :model_name, :attribute, :action
+    attr_reader :model_name, :attribute, :action, :presenter
 
-    def initialize(model_name, attribute, action)
+    def initialize(model_name, attribute, action, presenter)
       @model_name = model_name
       @attribute = attribute
       @action = action
+      @presenter = presenter
     end
 
     def to_str
@@ -34,6 +35,7 @@ module Formulaic
 
     def lookup_paths
       [
+        :"#{model_name}.#{attribute}.#{presenter}",
         :"#{model_name}.#{action}.#{attribute}",
         :"#{model_name}.#{attribute}",
         :"defaults.#{action}.#{attribute}",

--- a/spec/formulaic/form_spec.rb
+++ b/spec/formulaic/form_spec.rb
@@ -3,7 +3,13 @@ require 'spec_helper'
 describe Formulaic::Form do
   context "attribute is invalid type" do
     it "throws an error" do
-      expect { Formulaic::Form.new(nil, nil, { invalid: nil }) }.to raise_error(Formulaic::Form::InvalidAttributeTypeError)
+      invalid_attribute_error = Formulaic::Form::InvalidAttributeTypeError
+
+      expect{ formulaic_request }.to raise_error(invalid_attribute_error)
+    end
+
+    def formulaic_request
+      Formulaic::Form.new(nil, nil, { invalid: nil })
     end
   end
 end

--- a/spec/formulaic/form_spec.rb
+++ b/spec/formulaic/form_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 
 describe Formulaic::Form do
-  it 'throws an error if it does not know how to fill an attribute type' do
-    expect { Formulaic::Form.new(nil, nil, { invalid: nil }) }.to raise_error(Formulaic::Form::InvalidAttributeTypeError)
+  context "attribute is invalid type" do
+    it "throws an error" do
+      expect { Formulaic::Form.new(nil, nil, { invalid: nil }) }.to raise_error(Formulaic::Form::InvalidAttributeTypeError)
+    end
   end
 end

--- a/spec/formulaic/label_spec.rb
+++ b/spec/formulaic/label_spec.rb
@@ -35,10 +35,6 @@ describe Formulaic::Label do
     end
   end
 
-  it "should leave cases alone" do
-    expect(label(:user, "Work URL")).to eq "Work URL"
-  end
-
   def label(model_name, attribute, action = :new)
     Formulaic::Label.new(model_name, attribute, action).to_str
   end

--- a/spec/formulaic/label_spec.rb
+++ b/spec/formulaic/label_spec.rb
@@ -8,22 +8,28 @@ describe Formulaic::Label do
   end
 
   context "attribute is not a string" do
-    context "human_attribute_name is available" do
-      it "returns human_attribute_name" do
-        expect(label(:user, :first_name)).to eq "First name"
+    context "translation is available" do
+      it "uses a translation" do
+        create_translation_for({ user: { name: "First name"}})
+
+        expect(label(:user, :name)).to eq("First name")
       end
     end
 
-    context "translation is available" do
-      it "uses a translation" do
-        I18n.backend.store_translations(:en, { simple_form: { labels: { user: { name: "Translated" } } } } )
+    context "translation is not available" do
+      context "human_attribute_name is available" do
+        it "returns human_attribute_name" do
+          create_translation_for({ user: { name: nil}})
 
-        expect(label(:user, :name)).to eq("Translated")
+          expect(label(:user, :name)).to eq "Name"
+        end
       end
 
       context "model is not found" do
         it "uses the attribute as a string" do
-          expect(label(:student, "Course selection")).to eq "Course selection"
+          create_translation_for({ student: nil })
+
+          expect(label(:student, "Course_selection")).to eq "Course_selection"
         end
       end
     end
@@ -35,5 +41,11 @@ describe Formulaic::Label do
 
   def label(model_name, attribute, action = :new)
     Formulaic::Label.new(model_name, attribute, action).to_str
+  end
+
+  def create_translation_for(label)
+    I18n.backend.store_translations(
+      :en, { simple_form: { labels: label } }
+    )
   end
 end

--- a/spec/formulaic/label_spec.rb
+++ b/spec/formulaic/label_spec.rb
@@ -1,28 +1,38 @@
 require "spec_helper"
 
 describe Formulaic::Label do
-  it "returns the string if there are no translations and it can not human_attribute_name the class" do
-    expect(label(nil, "My label")).to eq "My label"
+  context "attribute is a string" do
+    it "returns the string" do
+      expect(label(nil, "My label")).to eq "My label"
+    end
   end
 
-  it "returns human_attribute_name if available" do
-    expect(label(:user, :first_name)).to eq "First name"
-  end
+  context "attribute is not a string" do
+    context "human_attribute_name is available" do
+      it "returns human_attribute_name" do
+        expect(label(:user, :first_name)).to eq "First name"
+      end
+    end
 
-  it "uses a translation if available" do
-    I18n.backend.store_translations(:en, { simple_form: { labels: { user: { name: "Translated" } } } } )
+    context "translation is available" do
+      it "uses a translation" do
+        I18n.backend.store_translations(:en, { simple_form: { labels: { user: { name: "Translated" } } } } )
 
-    expect(label(:user, :name)).to eq("Translated")
+        expect(label(:user, :name)).to eq("Translated")
 
-    I18n.backend.store_translations(:en, { simple_form: { labels: { user: { name: nil } } } } )
+        I18n.backend.store_translations(:en, { simple_form: { labels: { user: { name: nil } } } } )
+      end
+
+      context "model is not found" do
+        it "uses the attribute as a string" do
+          expect(label(:student, "Course selection")).to eq "Course selection"
+        end
+      end
+    end
   end
 
   it "should leave cases alone" do
     expect(label(:user, "Work URL")).to eq "Work URL"
-  end
-
-  it "uses the attribute when the model is not found" do
-    expect(label(:student, "Course selection")).to eq "Course selection"
   end
 
   def label(model_name, attribute, action = :new)

--- a/spec/formulaic/label_spec.rb
+++ b/spec/formulaic/label_spec.rb
@@ -9,10 +9,20 @@ describe Formulaic::Label do
 
   context "attribute is not a string" do
     context "translation is available" do
-      it "uses a translation" do
-        create_translation_for({ user: { name: "First name"}})
+      context "no presenter provided" do
+        it "uses a translation" do
+          create_translation_for({ user: { name: "First name"}})
 
-        expect(label(:user, :name)).to eq("First name")
+          expect(label(:user, :name)).to eq("First name")
+        end
+      end
+
+      context "presenter provided" do
+        it "uses a translation" do
+          create_translation_for({ user: { name: { presenter: "First name"}}})
+
+          expect(label(:user, :name, presenter: :presenter)).to eq("First name")
+        end
       end
     end
 
@@ -35,8 +45,8 @@ describe Formulaic::Label do
     end
   end
 
-  def label(model_name, attribute, action = :new)
-    Formulaic::Label.new(model_name, attribute, action).to_str
+  def label(model_name, attribute, action = :new, presenter: :nil)
+    Formulaic::Label.new(model_name, attribute, action, presenter).to_str
   end
 
   def create_translation_for(label)

--- a/spec/formulaic/label_spec.rb
+++ b/spec/formulaic/label_spec.rb
@@ -19,8 +19,6 @@ describe Formulaic::Label do
         I18n.backend.store_translations(:en, { simple_form: { labels: { user: { name: "Translated" } } } } )
 
         expect(label(:user, :name)).to eq("Translated")
-
-        I18n.backend.store_translations(:en, { simple_form: { labels: { user: { name: nil } } } } )
       end
 
       context "model is not found" do


### PR DESCRIPTION
Branching off [the previous PR](https://github.com/thoughtbot/formulaic/pull/56), the latest commit on this PR allows form attributes to pass presenters so that formulaic can search for the appropriate presenter-dependent label translations.