### PR TITLE
Humanize attribute when translation fails and class does not exist

### DIFF
--- a/lib/formulaic/label.rb
+++ b/lib/formulaic/label.rb
@@ -12,7 +12,7 @@ module Formulaic
       if attribute.is_a?(String)
         attribute
       else
-        translate || human_attribute_name || attribute.to_s
+        translate || human_attribute_name || attribute.to_s.humanize
       end
     end
     alias_method :to_s, :to_str

--- a/spec/formulaic/label_spec.rb
+++ b/spec/formulaic/label_spec.rb
@@ -25,6 +25,10 @@ describe Formulaic::Label do
     expect(label(:student, "Course selection")).to eq "Course selection"
   end
 
+  it "humanizes attribute if no translation is found and human_attribute_name is not available" do
+    expect(label(:student, :course_selection)).to eq "Course selection"
+  end
+
   def label(model_name, attribute, action = :new)
     Formulaic::Label.new(model_name, attribute, action).to_str
   end


### PR DESCRIPTION
Humanizing `attribute.to_s` match's Rails' default behavior for
generating the label text from the attribute when no class can be found
for the `model_name` being used. This occurs when a form has two sets of
inputs corresponding to the same model and is using aliases to avoid
name collisions (i.e. billing and shipping addresses backed by an
`Address` model).
