### PR TITLE
Use Integer instead of deprecated Fixnum

### DIFF
--- a/lib/formulaic/form.rb
+++ b/lib/formulaic/form.rb
@@ -9,7 +9,7 @@ module Formulaic
       Array => Formulaic::Inputs::ArrayInput,
       String => Formulaic::Inputs::StringInput,
       Symbol => Formulaic::Inputs::StringInput,
-      Fixnum => Formulaic::Inputs::StringInput,
+      1.class => Formulaic::Inputs::StringInput,
       Float => Formulaic::Inputs::StringInput,
       TrueClass => Formulaic::Inputs::BooleanInput,
       FalseClass => Formulaic::Inputs::BooleanInput,


### PR DESCRIPTION
Ruby 2.4 has deprecated the `Fixnum` and `Bignum` constants in favor of
the `Integer` constant. For backward compatibility, use `1.class` to
find the class of an integer.

Closes #61.