### PR TITLE
Add additional I18n label fallbacks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+master
+------
+
+* Add Rails `helpers.label` and `activerecord.attributes` fallback scopes for
+  label string internationalization [#67].
+
+  *Sean Doyle*
+
+[#67]: https://github.com/thoughtbot/formulaic/pull/67
+
 v0.1.1
 ------
 

--- a/lib/formulaic/label.rb
+++ b/lib/formulaic/label.rb
@@ -20,7 +20,7 @@ module Formulaic
     private
 
     def translate
-      I18n.t(lookup_paths.first, scope: :'simple_form.labels', default: lookup_paths).presence
+      I18n.t(lookup_paths.first, default: lookup_paths).presence
     end
 
     def human_attribute_name
@@ -34,10 +34,13 @@ module Formulaic
 
     def lookup_paths
       [
-        :"#{model_name}.#{action}.#{attribute}",
-        :"#{model_name}.#{attribute}",
-        :"defaults.#{action}.#{attribute}",
-        :"defaults.#{attribute}",
+        :"simple_form.labels.#{model_name}.#{action}.#{attribute}",
+        :"simple_form.labels.#{model_name}.#{attribute}",
+        :"simple_form.labels.defaults.#{action}.#{attribute}",
+        :"simple_form.labels.defaults.#{attribute}",
+        :"activerecord.attributes.#{model_name}.#{attribute}",
+        :"helpers.label.#{model_name}.#{attribute}",
+        :"helpers.label.text",
         '',
       ]
     end

--- a/spec/formulaic/label_spec.rb
+++ b/spec/formulaic/label_spec.rb
@@ -11,8 +11,7 @@ describe Formulaic::Label do
 
   context "when simple_form translations are available" do
     it "uses simple_form translation" do
-      I18n.reload!
-      I18n.backend.store_translations(:en, {
+      store_translations(
         simple_form: {
           labels: {
             user: {
@@ -20,7 +19,7 @@ describe Formulaic::Label do
             },
           },
         },
-      })
+      )
 
       expect(label(:user, :name)).to eq("Translated")
     end
@@ -28,8 +27,7 @@ describe Formulaic::Label do
 
   context "when helpers.label.<model> translations are available" do
     it "uses helpers.label translation" do
-      I18n.reload!
-      I18n.backend.store_translations(:en, {
+      store_translations(
         helpers: {
           label: {
             user: {
@@ -37,7 +35,7 @@ describe Formulaic::Label do
             },
           },
         },
-      })
+      )
 
       expect(label(:user, :name)).to eq("Translated")
     end
@@ -45,14 +43,13 @@ describe Formulaic::Label do
 
   context "when helpers.label.text default translations are available" do
     it "uses helpers.label.text translations" do
-      I18n.reload!
-      I18n.backend.store_translations(:en, {
+      store_translations(
         helpers: {
           label: {
             text: "Default",
           },
         },
-      })
+      )
 
       expect(label(:user, :name)).to eq("Default")
     end
@@ -60,8 +57,7 @@ describe Formulaic::Label do
 
   context "when activerecord.attributes.<model> translations are available" do
     it "uses activerecord.attributes translations" do
-      I18n.reload!
-      I18n.backend.store_translations(:en, {
+      store_translations(
         activerecord: {
           attributes: {
             user: {
@@ -69,7 +65,7 @@ describe Formulaic::Label do
             },
           },
         },
-      })
+      )
 
       expect(label(:user, :name)).to eq("Translated")
     end
@@ -85,6 +81,11 @@ describe Formulaic::Label do
 
   it "humanizes attribute if no translation is found and human_attribute_name is not available" do
     expect(label(:student, :course_selection)).to eq "Course selection"
+  end
+
+  def store_translations(translations)
+      I18n.reload!
+      I18n.backend.store_translations(:en, translations)
   end
 
   def label(model_name, attribute, action = :new)

--- a/spec/formulaic/label_spec.rb
+++ b/spec/formulaic/label_spec.rb
@@ -9,12 +9,70 @@ describe Formulaic::Label do
     expect(label(:user, :first_name)).to eq "First name"
   end
 
-  it "uses a translation if available" do
-    I18n.backend.store_translations(:en, { simple_form: { labels: { user: { name: "Translated" } } } } )
+  context "when simple_form translations are available" do
+    it "uses simple_form translation" do
+      I18n.reload!
+      I18n.backend.store_translations(:en, {
+        simple_form: {
+          labels: {
+            user: {
+              name: "Translated"
+            },
+          },
+        },
+      })
 
-    expect(label(:user, :name)).to eq("Translated")
+      expect(label(:user, :name)).to eq("Translated")
+    end
+  end
 
-    I18n.backend.store_translations(:en, { simple_form: { labels: { user: { name: nil } } } } )
+  context "when helpers.label.<model> translations are available" do
+    it "uses helpers.label translation" do
+      I18n.reload!
+      I18n.backend.store_translations(:en, {
+        helpers: {
+          label: {
+            user: {
+              name: "Translated"
+            },
+          },
+        },
+      })
+
+      expect(label(:user, :name)).to eq("Translated")
+    end
+  end
+
+  context "when helpers.label.text default translations are available" do
+    it "uses helpers.label.text translations" do
+      I18n.reload!
+      I18n.backend.store_translations(:en, {
+        helpers: {
+          label: {
+            text: "Default",
+          },
+        },
+      })
+
+      expect(label(:user, :name)).to eq("Default")
+    end
+  end
+
+  context "when activerecord.attributes.<model> translations are available" do
+    it "uses activerecord.attributes translations" do
+      I18n.reload!
+      I18n.backend.store_translations(:en, {
+        activerecord: {
+          attributes: {
+            user: {
+              name: "Translated"
+            },
+          },
+        },
+      })
+
+      expect(label(:user, :name)).to eq("Translated")
+    end
   end
 
   it "should leave cases alone" do


### PR DESCRIPTION
Prior to this commit, Formulaic assumed that all labels would be
declared as part of `simple_form` configuration.

This commit extends the list of possible internationalization keys that
Formulaic will look up, based on [existing Rails conventions][api-docs].

[api-docs]: http://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-label