### PR TITLE
Add support for additional I18n label scopes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+master
+------
+
+* Add support for additional translation lookup paths for label string
+  internationalization (like Rails `helpers.label` and `activerecord.attributes`
+  scopes)
+
 v0.1.1
 ------
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ Formulaic assumes your forms don't use AJAX, setting the wait time to 0. This ca
 Formulaic.default_wait_time = 5
 ```
 
+### Additional Translation Lookup Paths
+
+If you'd like to add additional translation lookup paths, append them through
+configuration:
+
+```rb
+Formulaic.configure do |config|
+  config.translation_scopes << "helpers.label"
+  config.translation_scopes << "activerecord.attributes"
+end
+```
+
 ## Known Limitations
 
 * Formulaic currently supports the following mappings from the `#class` of the

--- a/lib/formulaic.rb
+++ b/lib/formulaic.rb
@@ -8,7 +8,7 @@ require 'formulaic/dsl'
 
 module Formulaic
   class << self
-    attr_accessor :default_wait_time
+    attr_accessor :default_wait_time, :translation_scopes
 
     def configure
       yield self
@@ -18,4 +18,5 @@ end
 
 Formulaic.configure do |config|
   config.default_wait_time = 0
+  config.translation_scopes = Formulaic::Label.translation_scopes
 end


### PR DESCRIPTION
Prior to this commit, Formulaic assumed that all labels would be
declared as part of `simple_form` configuration.

This commit adds support for extending the list of possible
internationalization keys that Formulaic will look up.

For example, to lookup translations with [existing Rails
conventions][api-docs], users can configure `Formulaic` like so:

```rb
Formulaic.configure do |config|
  config.translation_scopes << "helpers.label"
  config.translation_scopes << "activerecord.attributes"
end
```

This is a looser follow-up pull request to [#67], which was denied and
closed on the grounds of keeping this gem SimpleForm-only.

While this change opens the door for users to extend the gem, it sticks
with SimpleForm defaults when un-configured.

[api-docs]: http://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-label
[#67]: https://github.com/thoughtbot/formulaic/pull/67